### PR TITLE
feat(formatting): Add custom Erlang formatter

### DIFF
--- a/nvim/lua/plugins/formatting.lua
+++ b/nvim/lua/plugins/formatting.lua
@@ -21,6 +21,14 @@ return {
       ["handlebars"] = { "prettier" },
       ["lua"] = { "stylua" },
       ["python"] = { "autopep8" },
+      ["erlang"] = { "erlfmt" },
+    },
+    formatters = {
+      erlfmt = {
+        command = "rebar3",
+        args = { "fmt", "$FILENAME" },
+        stdin = false,
+      },
     },
   },
 }


### PR DESCRIPTION
Adds custom Erlang formatter through conform.nvim.
Relies on `rebar3` being installed and the `fmt` rebar script being set up.