### PR TITLE
fix(tmux): Remove conflicting keybinding

### DIFF
--- a/dot_config/tmux/tmux.conf
+++ b/dot_config/tmux/tmux.conf
@@ -19,9 +19,6 @@ bind r source-file ~/.config/tmux/tmux.conf\; display "tmux config reloaded"
 
 # Session navigation
 bind -r q confirm-before -p "kill window #W? (y/n)" kill-window
-bind -r f run-shell "tmux neww ~/dev/dotfiles/tmux-pick-session"
-bind -r C-f run-shell "tmux neww ~/dev/dotfiles/tmux-pick-session"  # just for times when Ctrl key is still pressed due to prefix being pressed before
-bind -n C-f run-shell "tmux neww ~/dev/dotfiles/tmux-pick-session"  # having this will mess up Vimʼs `C-f`, still worth it
 
 # Window navigation when Ctrl is pressed
 bind -r C-n next-window


### PR DESCRIPTION
Remove tmux keybinding that A) conflicted with the keybinding already defined in `~/.zshrc` and B) was mapped to use a now deprecated file path.
