### PR TITLE
fix(tmux): Restore session picker keybindings with correct script path

### DIFF
--- a/dot_config/tmux/tmux.conf
+++ b/dot_config/tmux/tmux.conf
@@ -19,6 +19,9 @@ bind r source-file ~/.config/tmux/tmux.conf\; display "tmux config reloaded"
 
 # Session navigation
 bind -r q confirm-before -p "kill window #W? (y/n)" kill-window
+bind -r f run-shell "tmux neww ~/bin/tmux-pick-session"
+bind -r C-f run-shell "tmux neww ~/bin/tmux-pick-session"  # for when Ctrl is still held after pressing prefix
+bind -n C-f run-shell "tmux neww ~/bin/tmux-pick-session"  # global — intercepts C-f in all programs (intentional, sacrifices Vim's page-forward)
 
 # Window navigation when Ctrl is pressed
 bind -r C-n next-window


### PR DESCRIPTION
## Summary
- PR #27 removed the `C-f` session picker bindings citing a deprecated script path and a conflict with the zshrc `bindkey`
- Restores the bindings pointing to the correct path (`~/bin/tmux-pick-session`)
- The zshrc `bindkey -s ^f` is not a conflict — it handles the non-tmux case where `bind -n C-f` is not active

`bind -n C-f` intentionally intercepts `C-f` globally (including inside running programs like Vim), sacrificing Vim's page-forward in favour of always-available session switching.