### PR TITLE
feat(ssh): Add github-personal alias + safe re-run path to setup-ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ HTTPS is used so this works on a fresh machine before SSH is set up. On apply, c
 - install the mise-managed runtimes from `~/.tool-versions` (prompted);
 - optionally apply macOS defaults from `.macos` (prompted);
 - prompt for your global Git identity (stored in `~/.gitconfig.local`);
-- optionally set up a personal SSH key/identity for this repo (prompted).
+- optionally set up a personal SSH key/identity + `github-personal` ssh alias for this repo (prompted).
 
 Each prompted step is skipped automatically when run without a TTY (CI, piped).
 
@@ -55,10 +55,24 @@ re-prompted if that file goes missing); `~/.gitconfig` includes it. Because `~/.
 is not managed by chezmoi, later edits stick and aren't reverted by `chezmoi apply`.
 
 `run_once_setup-ssh.sh` optionally configures a **personal** SSH key + identity for *this dotfiles
-repo only* (written to the repo's `.git/config`) and installs `pre-commit` / `pre-push` hooks that
-block commits/pushes made under the wrong identity. It does **not** rewrite the remote: if origin
-isn't already an SSH URL it prints the `git remote set-url` command to switch it, and the
-`pre-push` hook blocks pushes until you do.
+repo only*. It writes the identity and key choice to the repo's `.git/config`, ensures a
+`Host github-personal` alias block in `~/.ssh/config` (so only the personal key is ever offered to
+GitHub — even on machines whose `Host github.com` entry carries another identity), rewrites a
+github.com origin (HTTPS or SSH) to `git@github-personal:<owner>/<repo>.git`, and installs
+`pre-commit` / `pre-push` hooks that block commits/pushes made under the wrong identity, via a
+non-alias remote, or via an alias that no longer resolves to github.com with the recorded key. A pre-existing
+`Host github-personal` block pointing at a different key is never modified — the script warns and
+the `pre-push` hook blocks pushes until it's reconciled by hand.
+
+When the repo is already set up (`hooks.sshKey` set and the key exists), re-runs — after this
+script's contents change, or a manual invocation — offer to set it up again instead of running
+full setup: make sure commits/pushes use your personal Git identity, and route origin through the
+`github-personal` alias (rewriting origin and editing `~/.ssh/config`). It does this only after an
+interactive y/N; with no controlling terminal (CI, piped, cron) it does nothing and leaves
+everything untouched — nothing is modified without a confirmation. It is also **not** drift
+recovery: chezmoi only re-runs a `run_once_` script when its *contents* change, so deleting the
+alias block or `.git/hooks` won't trigger it on its own — the `pre-push` hook blocks until you
+re-run the script.
 
 > **Manual-clone caveat:** git never runs hooks from a freshly cloned repo, and `.git/hooks` is
 > not part of a clone — so the identity-guard hooks exist only after `setup-ssh` runs during an

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ github.com origin (HTTPS or SSH) to `git@github-personal:<owner>/<repo>.git`, an
 `pre-commit` / `pre-push` hooks that block commits/pushes made under the wrong identity, via a
 non-alias remote, or via an alias that no longer resolves to github.com with the recorded key. A pre-existing
 `Host github-personal` block pointing at a different key is never modified — the script warns and
-the `pre-push` hook blocks pushes until it's reconciled by hand.
+the `pre-push` hook blocks pushes until you point its `IdentityFile` at the selected key.
 
 When the repo is already set up (`hooks.sshKey` set and the key exists), re-runs — after this
 script's contents change, or a manual invocation — offer to set it up again instead of running

--- a/README.md
+++ b/README.md
@@ -60,9 +60,10 @@ repo only*. It writes the identity and key choice to the repo's `.git/config`, e
 GitHub — even on machines whose `Host github.com` entry carries another identity), rewrites a
 github.com origin (HTTPS or SSH) to `git@github-personal:<owner>/<repo>.git`, and installs
 `pre-commit` / `pre-push` hooks that block commits/pushes made under the wrong identity, via a
-non-alias remote, or via an alias that no longer resolves to github.com with the recorded key. A pre-existing
-`Host github-personal` block pointing at a different key is never modified — the script warns and
-the `pre-push` hook blocks pushes until you point its `IdentityFile` at the selected key.
+non-alias remote, or via an alias that no longer resolves to github.com with the recorded key. A
+pre-existing `Host github-personal` block pointing at a different key is never modified — the
+script warns and the `pre-push` hook blocks pushes until you point its `IdentityFile` at the
+selected key.
 
 When the repo is already set up (`hooks.sshKey` set and the key exists), re-runs — after this
 script's contents change, or a manual invocation — offer to set it up again instead of running

--- a/run_once_setup-ssh.sh
+++ b/run_once_setup-ssh.sh
@@ -1,14 +1,248 @@
 #!/bin/bash
-# Optional, per-machine personal SSH identity for the dotfiles repo. Runs once.
+# Optional, per-machine personal SSH identity for the dotfiles repo.
 # Everything is gathered via prompts and written ONLY to the dotfiles repo's own
-# .git/config and .git/hooks — nothing is stored in chezmoi.
+# .git/config + .git/hooks and ~/.ssh/config — nothing is stored in chezmoi.
+#
+# Two paths:
+#   - Already set up (hooks.sshKey set and the key exists): offer to set it up
+#     again — make sure commits/pushes use your personal Git identity, route
+#     origin through the ssh alias, and edit ~/.ssh/config. This runs only after
+#     an interactive y/N; with no controlling terminal it does nothing and
+#     leaves everything untouched — nothing here is modified without a
+#     confirmation.
+#   - Otherwise: full interactive setup below.
 #
 # Because this is run_once, declining now means it won't re-run automatically. To
 # set it up later, run this script manually or clear its chezmoi script state.
 
+# Dedicated ssh Host alias for this repo's origin. With the remote on the alias,
+# only the alias' Host block matches (ssh matches on the name as typed, not the
+# resolved HostName), so the personal key is the ONLY key ssh offers — even on
+# machines whose `Host github.com` entry carries another identity. A plain
+# git@github.com remote does not get that guarantee: both that block's
+# IdentityFile and core.sshCommand's -i count as "explicit" identities, and ssh
+# offers agent-resident explicit keys first — i.e. the other account's key can
+# win whenever it is in the agent and the personal key is not.
+alias_host="github-personal"
+
+# Use chezmoi's injected env var — calling `chezmoi` directly here deadlocks
+# because chezmoi is already the process running this script.
+repo="${CHEZMOI_SOURCE_DIR:-$(chezmoi source-path 2>/dev/null)}"
+if [ -z "$repo" ] || [ ! -d "$repo/.git" ]; then
+  echo "Could not resolve the chezmoi source repo (.git not found at '$repo'); aborting." >&2
+  exit 1
+fi
+
+ssh_dir="$HOME/.ssh"
+ssh_config="$ssh_dir/config"
+
+# Ensure ~/.ssh/config has a Host block for $alias_host pointing at the given key.
+# Existence is checked with `ssh -G` rather than grep so a block defined via an
+# Include also counts. If the alias exists but resolves to a different key, warn
+# and leave it alone — we never rewrite pre-existing ssh config; the pre-push
+# hook blocks pushes until it is reconciled.
+ensure_alias_block() {
+  local key="$1" resolved_hostname resolved_keys key_display
+  resolved_hostname="$(ssh -G "$alias_host" 2>/dev/null | awk '/^hostname /{print $2}')"
+  if [ "$resolved_hostname" = "github.com" ]; then
+    # Block already present. Warn (never rewrite) if it points at a different key.
+    # `sed -n 's/^identityfile //p'` keeps the whole path — robust to spaces, unlike
+    # awk '{print $2}'; ssh -G emits the path with ~ unexpanded, so fold it to $HOME.
+    resolved_keys="$(ssh -G "$alias_host" 2>/dev/null | sed -n 's/^identityfile //p' | sed "s|^~|$HOME|")"
+    if [ "$resolved_keys" != "$key" ]; then
+      echo "WARNING: 'Host $alias_host' already exists in your ssh config but resolves to:" >&2
+      printf '%s\n' "$resolved_keys" | sed 's/^/    /' >&2
+      echo "  instead of the selected key: $key" >&2
+      echo "  Left untouched — align its IdentityFile manually; pushes are blocked until then." >&2
+    fi
+    return 0
+  elif [ "$resolved_hostname" != "$alias_host" ]; then
+    # A 'Host $alias_host' block exists but points somewhere other than github.com
+    # (when no block matches, ssh -G echoes the literal alias back as the hostname).
+    # Don't append a duplicate — warn and leave it for manual reconciliation.
+    echo "WARNING: 'Host $alias_host' already exists but resolves to HostName '$resolved_hostname', not github.com." >&2
+    echo "  Left untouched to avoid a duplicate block; reconcile it manually." >&2
+    return 0
+  fi
+
+  mkdir -p "$ssh_dir"
+  chmod 700 "$ssh_dir"
+  if [ ! -f "$ssh_config" ]; then
+    touch "$ssh_config"
+    chmod 600 "$ssh_config"
+  fi
+  # Append, never prepend — e.g. OrbStack's Include must stay at the top of the file.
+  key_display="${key/#$HOME/\~}"
+  {
+    echo ""
+    echo "# Personal GitHub identity for the dotfiles repo — added by setup-ssh (chezmoi)"
+    echo "Host $alias_host"
+    echo "  HostName github.com"
+    echo "  IdentityFile $key_display"
+    echo "  IdentitiesOnly yes"
+  } >>"$ssh_config"
+  echo "Added 'Host $alias_host' to $ssh_config (IdentityFile $key_display)."
+}
+
+# Point origin at the alias so pushes can only ever offer the personal key.
+# Rewrites github.com URLs only (HTTPS or SSH) — turning an arbitrary host's URL
+# into the matching SSH one is host-specific and easy to get wrong, so other
+# hosts just get a heads-up; the pre-push hook blocks pushes until origin uses
+# the alias, so this is a nudge, not a hard failure.
+ensure_remote() {
+  local origin_url path new_url
+  origin_url="$(git -C "$repo" config remote.origin.url)"
+  case "$origin_url" in
+    git@"$alias_host":* | ssh://git@"$alias_host"/*)
+      ;; # already on the alias — nothing to do
+    https://github.com/* | git@github.com:* | ssh://git@github.com/*)
+      path="${origin_url#https://github.com/}"
+      path="${path#git@github.com:}"
+      path="${path#ssh://git@github.com/}"
+      new_url="git@$alias_host:${path%.git}.git"
+      git -C "$repo" remote set-url origin "$new_url"
+      echo "Rewrote origin: $origin_url -> $new_url"
+      ;;
+    *)
+      echo "NOTE: origin is '$origin_url' (not a github.com URL); pushes are blocked" >&2
+      echo "until it uses the '$alias_host' alias, e.g.:" >&2
+      echo "  git -C \"$repo\" remote set-url origin git@$alias_host:<owner>/<repo>.git" >&2
+      ;;
+  esac
+}
+
+# Guard hooks: block commits/pushes made under the wrong identity or via the
+# wrong remote/key. They read the expected values from the repo's git config at
+# run time rather than having them baked into their text, so a value containing
+# quotes (or $, backticks) can't produce a malformed hook script. Heredocs are
+# quoted (<<'EOF') so the hook bodies are written verbatim.
+install_hooks() {
+  local hook_dir="$repo/.git/hooks"
+
+  cat >"$hook_dir/pre-commit" <<'EOF'
+#!/bin/bash
+expected_name="$(git config hooks.expectedName)"
+expected_email="$(git config hooks.expectedEmail)"
+actual_name="$(git config user.name)"
+actual_email="$(git config user.email)"
+if [ "$actual_name" != "$expected_name" ] || [ "$actual_email" != "$expected_email" ]; then
+  echo "BLOCKED: dotfiles repo commit identity ($actual_name <$actual_email>) != expected ($expected_name <$expected_email>)" >&2
+  echo "Fix: git config user.name \"$expected_name\" && git config user.email \"$expected_email\"" >&2
+  exit 1
+fi
+EOF
+
+  cat >"$hook_dir/pre-push" <<'EOF'
+#!/bin/bash
+expected_name="$(git config hooks.expectedName)"
+expected_email="$(git config hooks.expectedEmail)"
+actual_name="$(git config user.name)"
+actual_email="$(git config user.email)"
+if [ "$actual_name" != "$expected_name" ] || [ "$actual_email" != "$expected_email" ]; then
+  echo "BLOCKED: dotfiles repo push identity ($actual_name <$actual_email>) != expected ($expected_name <$expected_email>)" >&2
+  exit 1
+fi
+remote="$(git config remote.origin.url)"
+# Enforce SSH so pushes use the key/identity above, not a cached HTTPS credential.
+case "$remote" in
+  git@* | ssh://*) ;;
+  *) echo "BLOCKED: origin is not an SSH URL ($remote)" >&2; exit 1 ;;
+esac
+key="$(git config hooks.sshKey)"
+key="${key/#\~/$HOME}"
+if [ -n "$key" ] && [ ! -f "$key" ]; then
+  echo "BLOCKED: SSH key recorded for this repo not found: $key" >&2
+  exit 1
+fi
+# When an alias is recorded: require origin to use it, require the alias to
+# resolve (a deleted ssh config block otherwise surfaces as a cryptic DNS
+# error), and require it to resolve to exactly the recorded key — a second
+# candidate key would reintroduce the wrong-account ambiguity this setup
+# exists to prevent. `ssh -G` only parses local config; no network involved.
+alias_host="$(git config hooks.sshHostAlias)"
+if [ -n "$alias_host" ]; then
+  case "$remote" in
+    git@"$alias_host":* | ssh://git@"$alias_host"/*) ;;
+    *)
+      echo "BLOCKED: origin must use the '$alias_host' alias (got: $remote)" >&2
+      echo "Fix: git remote set-url origin git@$alias_host:<owner>/<repo>.git" >&2
+      exit 1
+      ;;
+  esac
+  resolved_hostname="$(ssh -G "$alias_host" 2>/dev/null | awk '/^hostname /{print $2}')"
+  if [ "$resolved_hostname" != "github.com" ]; then
+    echo "BLOCKED: 'Host $alias_host' does not resolve to github.com in your ssh config" >&2
+    echo "(missing block?). Re-run setup-ssh / chezmoi apply to restore it." >&2
+    exit 1
+  fi
+  # sed (not awk '{print $2}') so a key path containing spaces survives intact.
+  resolved_keys="$(ssh -G "$alias_host" 2>/dev/null | sed -n 's/^identityfile //p' | sed "s|^~|$HOME|")"
+  if [ "$resolved_keys" != "$key" ]; then
+    echo "BLOCKED: 'Host $alias_host' resolves to different key(s) than the recorded $key:" >&2
+    printf '%s\n' "$resolved_keys" | sed 's/^/    /' >&2
+    echo "Align the IdentityFile in your ssh config with hooks.sshKey." >&2
+    exit 1
+  fi
+fi
+EOF
+
+  chmod +x "$hook_dir/pre-commit" "$hook_dir/pre-push"
+}
+
+# Is a controlling terminal available to prompt on? (chezmoi runs scripts with
+# stdin detached, so we test /dev/tty directly rather than -t 0.)
+has_tty() { { : </dev/tty; } 2>/dev/null; }
+
+# --- Already set up? Offer to set it up again, then exit. ---------------------
+# Setting it up again changes things — it makes sure commits/pushes use your
+# personal Git identity, routes origin through the ssh alias, and edits
+# ~/.ssh/config. None of it happens without an interactive confirmation: with no
+# controlling terminal we leave everything untouched. (Not drift recovery
+# either — the pre-push hook blocks pushes until you re-run this in a terminal
+# and confirm.)
+configured_key="$(git -C "$repo" config hooks.sshKey)"
+configured_key="${configured_key/#\~/$HOME}"
+if [ -n "$configured_key" ]; then
+  if [ -f "$configured_key" ]; then
+    if ! has_tty; then
+      echo "This repo already has a personal SSH key recorded ($configured_key), and that"
+      echo "key exists on disk — so personal SSH is already set up. This run has no terminal"
+      echo "to confirm changes on, so nothing was modified. Run this script from an"
+      echo "interactive terminal if you want to set it up again."
+      exit 0
+    fi
+    echo "This repo already has a personal SSH key recorded ($configured_key), and that"
+    echo "key exists on disk — so personal SSH is already set up."
+    echo
+    echo "If you want to, you can set it up again. This will:"
+    echo "  1. make sure commits and pushes here go out under your personal Git identity,"
+    echo "     not a work one"
+    echo "  2. route this repo's remote through a dedicated '$alias_host' SSH alias so"
+    echo "     only your personal key is offered to GitHub, rewriting origin to"
+    echo "     git@$alias_host:<owner>/<repo>.git"
+    echo "  3. add a 'Host $alias_host' block to $ssh_config"
+    echo
+    read -r -p "Set it up again now? (y/N) " response </dev/tty
+    case "$response" in
+      [yY][eE][sS] | [yY]) ;;
+      *) echo "Left everything untouched."; exit 0 ;;
+    esac
+    git -C "$repo" config core.sshCommand "ssh -i \"$configured_key\" -o IdentitiesOnly=yes"
+    git -C "$repo" config hooks.sshHostAlias "$alias_host"
+    install_hooks
+    ensure_alias_block "$configured_key"
+    ensure_remote
+    echo "Done — personal SSH set up for the dotfiles repo at $repo."
+    exit 0
+  fi
+  echo "WARNING: recorded personal SSH key '$configured_key' no longer exists; running full setup." >&2
+fi
+
+# --- Full interactive setup. ---------------------------------------------------
+
 # chezmoi does not attach the terminal to a script's stdin, so prompt via the
 # controlling terminal (/dev/tty). If there is none (CI, piped), skip.
-if ! { : </dev/tty; } 2>/dev/null; then
+if ! has_tty; then
   echo "No terminal; skipping personal SSH setup. Re-run this script manually to set it up."
   exit 0
 fi
@@ -22,7 +256,6 @@ esac
 read -r -p "Personal Git name: " personal_git_name </dev/tty
 read -r -p "Personal Git email: " personal_git_email </dev/tty
 
-ssh_dir="$HOME/.ssh"
 mkdir -p "$ssh_dir"
 chmod 700 "$ssh_dir"
 
@@ -77,84 +310,22 @@ cat "${selected_key}.pub"
 echo
 read -r -p "Press Enter once the key is added to GitHub... " _ </dev/tty
 
-# Use chezmoi's injected env var — calling `chezmoi` directly here deadlocks
-# because chezmoi is already the process running this script.
-repo="${CHEZMOI_SOURCE_DIR:-$(chezmoi source-path 2>/dev/null)}"
-if [ -z "$repo" ] || [ ! -d "$repo/.git" ]; then
-  echo "Could not resolve the chezmoi source repo (.git not found at '$repo'); aborting." >&2
-  exit 1
-fi
-
 git -C "$repo" config user.name "$personal_git_name"
 git -C "$repo" config user.email "$personal_git_email"
+# Kept alongside the alias as a second layer: even if the remote is somehow
+# changed to plain github.com, the personal key is at least in the offered set.
 git -C "$repo" config core.sshCommand "ssh -i \"$selected_key\" -o IdentitiesOnly=yes"
 
-# Store the expected identity in the repo's git config. The guard hooks below read it
-# at run time rather than having the name/email baked into their text, so a value
-# containing quotes (or $, backticks) can't produce a malformed hook script.
+# Store the expected identity in the repo's git config for the guard hooks.
 git -C "$repo" config hooks.expectedName "$personal_git_name"
 git -C "$repo" config hooks.expectedEmail "$personal_git_email"
 # Record the chosen key's path for the pre-push hook to verify. Stored directly (always
 # an absolute path) so the hook needn't parse core.sshCommand — robust even with spaces.
 git -C "$repo" config hooks.sshKey "$selected_key"
+git -C "$repo" config hooks.sshHostAlias "$alias_host"
 
-# Guard hooks: block commits/pushes made under the wrong identity. pre-push additionally
-# verifies the SSH remote and that the key recorded in hooks.sshKey still exists.
-# Heredocs are quoted (<<'EOF') so the hook bodies are written verbatim.
-hook_dir="$repo/.git/hooks"
-
-cat >"$hook_dir/pre-commit" <<'EOF'
-#!/bin/bash
-expected_name="$(git config hooks.expectedName)"
-expected_email="$(git config hooks.expectedEmail)"
-actual_name="$(git config user.name)"
-actual_email="$(git config user.email)"
-if [ "$actual_name" != "$expected_name" ] || [ "$actual_email" != "$expected_email" ]; then
-  echo "BLOCKED: dotfiles repo commit identity ($actual_name <$actual_email>) != expected ($expected_name <$expected_email>)" >&2
-  echo "Fix: git config user.name \"$expected_name\" && git config user.email \"$expected_email\"" >&2
-  exit 1
-fi
-EOF
-
-cat >"$hook_dir/pre-push" <<'EOF'
-#!/bin/bash
-expected_name="$(git config hooks.expectedName)"
-expected_email="$(git config hooks.expectedEmail)"
-actual_name="$(git config user.name)"
-actual_email="$(git config user.email)"
-if [ "$actual_name" != "$expected_name" ] || [ "$actual_email" != "$expected_email" ]; then
-  echo "BLOCKED: dotfiles repo push identity ($actual_name <$actual_email>) != expected ($expected_name <$expected_email>)" >&2
-  exit 1
-fi
-remote="$(git config remote.origin.url)"
-# Enforce SSH so pushes use the key/identity above, not a cached HTTPS credential.
-case "$remote" in
-  git@*|ssh://*) ;;
-  *) echo "BLOCKED: origin is not an SSH URL ($remote)" >&2; exit 1 ;;
-esac
-key="$(git config hooks.sshKey)"
-key="${key/#\~/$HOME}"
-if [ -n "$key" ] && [ ! -f "$key" ]; then
-  echo "BLOCKED: SSH key recorded for this repo not found: $key" >&2
-  exit 1
-fi
-EOF
-
-chmod +x "$hook_dir/pre-commit" "$hook_dir/pre-push"
+install_hooks
+ensure_alias_block "$selected_key"
+ensure_remote
 
 echo "Personal SSH identity configured for the dotfiles repo at $repo."
-
-# Require origin to be SSH so pushes use the personal key. We don't rewrite it
-# automatically — turning an arbitrary HTTPS URL into the matching SSH one is host-
-# specific and easy to get wrong. If it isn't SSH, print the command to fix it; the
-# pre-push hook blocks pushes until then, so this is a heads-up, not a hard failure.
-origin_url="$(git -C "$repo" config remote.origin.url)"
-case "$origin_url" in
-  git@*|ssh://*) ;; # already SSH — nothing to do
-  *)
-    echo
-    echo "NOTE: origin is '$origin_url' (not SSH). Switch it to your SSH URL so pushes" >&2
-    echo "use your key, e.g. (github.com shown as an example host):" >&2
-    echo "  git -C \"$repo\" remote set-url origin git@github.com:<owner>/<repo>.git" >&2
-    ;;
-esac

--- a/run_once_setup-ssh.sh
+++ b/run_once_setup-ssh.sh
@@ -53,6 +53,8 @@ ensure_alias_block() {
       echo "WARNING: 'Host $alias_host' already exists in your ssh config but resolves to:" >&2
       printf '%s\n' "$resolved_keys" | sed 's/^/    /' >&2
       echo "  instead of the selected key: $key" >&2
+      echo "  (If a 'Host *' block in your ssh config also sets IdentityFile, that key shows" >&2
+      echo "  up here too — remove it from 'Host *' so only this alias' key is offered.)" >&2
       echo "  Left untouched — align its IdentityFile manually; pushes are blocked until then." >&2
     fi
     return 0
@@ -88,13 +90,14 @@ ensure_alias_block() {
 # Rewrites github.com URLs only (HTTPS or SSH) — turning an arbitrary host's URL
 # into the matching SSH one is host-specific and easy to get wrong, so other
 # hosts just get a heads-up; the pre-push hook blocks pushes until origin uses
-# the alias, so this is a nudge, not a hard failure.
+# the alias, so this is a nudge, not a hard failure. Returns 0 when origin is on
+# the alias afterwards, 1 when the caller must still move it by hand.
 ensure_remote() {
   local origin_url path new_url
   origin_url="$(git -C "$repo" config remote.origin.url)"
   case "$origin_url" in
     git@"$alias_host":* | ssh://git@"$alias_host"/*)
-      ;; # already on the alias — nothing to do
+      return 0 ;; # already on the alias — nothing to do
     https://github.com/* | git@github.com:* | ssh://git@github.com/*)
       path="${origin_url#https://github.com/}"
       path="${path#git@github.com:}"
@@ -102,11 +105,13 @@ ensure_remote() {
       new_url="git@$alias_host:${path%.git}.git"
       git -C "$repo" remote set-url origin "$new_url"
       echo "Rewrote origin: $origin_url -> $new_url"
+      return 0
       ;;
     *)
       echo "NOTE: origin is '$origin_url' (not a github.com URL); pushes are blocked" >&2
       echo "until it uses the '$alias_host' alias, e.g.:" >&2
       echo "  git -C \"$repo\" remote set-url origin git@$alias_host:<owner>/<repo>.git" >&2
+      return 1
       ;;
   esac
 }
@@ -180,6 +185,8 @@ if [ -n "$alias_host" ]; then
   if [ "$resolved_keys" != "$key" ]; then
     echo "BLOCKED: 'Host $alias_host' resolves to different key(s) than the recorded $key:" >&2
     printf '%s\n' "$resolved_keys" | sed 's/^/    /' >&2
+    echo "(If a 'Host *' block in your ssh config also sets IdentityFile, that key shows" >&2
+    echo "up here too — remove it from 'Host *' so only this alias' key is offered.)" >&2
     echo "Align the IdentityFile in your ssh config with hooks.sshKey." >&2
     exit 1
   fi
@@ -231,8 +238,12 @@ if [ -n "$configured_key" ]; then
     git -C "$repo" config hooks.sshHostAlias "$alias_host"
     install_hooks
     ensure_alias_block "$configured_key"
-    ensure_remote
-    echo "Done — personal SSH set up for the dotfiles repo at $repo."
+    if ensure_remote; then
+      echo "Done — personal SSH set up for the dotfiles repo at $repo."
+    else
+      echo "Personal SSH set up for the dotfiles repo at $repo — but origin still needs"
+      echo "to point at the '$alias_host' alias (see the note above) before you can push."
+    fi
     exit 0
   fi
   echo "WARNING: recorded personal SSH key '$configured_key' no longer exists; running full setup." >&2
@@ -326,6 +337,10 @@ git -C "$repo" config hooks.sshHostAlias "$alias_host"
 
 install_hooks
 ensure_alias_block "$selected_key"
-ensure_remote
-
-echo "Personal SSH identity configured for the dotfiles repo at $repo."
+if ensure_remote; then
+  echo "Personal SSH identity configured for the dotfiles repo at $repo."
+else
+  echo "Personal SSH identity configured for the dotfiles repo at $repo — but origin"
+  echo "still needs to point at the '$alias_host' alias (see the note above) before you"
+  echo "can push."
+fi

--- a/run_once_setup-ssh.sh
+++ b/run_once_setup-ssh.sh
@@ -64,7 +64,7 @@ ensure_alias_block() {
   elif [ "$resolved_hostname" != "$alias_host" ]; then
     # A 'Host $alias_host' block exists but points somewhere other than github.com
     # (when no block matches, ssh -G echoes the literal alias back as the hostname).
-    # Don't append a duplicate — warn and leave it for manual reconciliation.
+    # Don't append a duplicate — warn and leave it for the user to fix by hand.
     echo "WARNING: 'Host $alias_host' already exists but resolves to HostName '$resolved_hostname', not github.com." >&2
     echo "  Left untouched to avoid a duplicate block; edit your ssh config so that" >&2
     echo "  'Host $alias_host' has 'HostName github.com', or remove the block and re-run." >&2

--- a/run_once_setup-ssh.sh
+++ b/run_once_setup-ssh.sh
@@ -106,6 +106,8 @@ ensure_remote() {
       path="${origin_url#https://github.com/}"
       path="${path#git@github.com:}"
       path="${path#ssh://git@github.com/}"
+      # git accepts a trailing slash on clone; drop it so it can't end up in the alias URL.
+      path="${path%/}"
       new_url="git@$alias_host:${path%.git}.git"
       git -C "$repo" remote set-url origin "$new_url"
       echo "Rewrote origin: $origin_url -> $new_url"

--- a/run_once_setup-ssh.sh
+++ b/run_once_setup-ssh.sh
@@ -77,8 +77,8 @@ ensure_alias_block() {
     touch "$ssh_config"
     chmod 600 "$ssh_config"
   fi
-  # Append, never prepend — e.g. OrbStack's Include must stay at the top of the file.
-  key_display="${key/#$HOME/\~}"
+  # Append, never prepend — e.g. some `Include` statements must stay at the top of the file.
+  key_display="${key/#$HOME/~}"
   {
     echo ""
     echo "# Personal GitHub identity for the dotfiles repo — added by setup-ssh (chezmoi)"
@@ -258,7 +258,7 @@ if [ -n "$configured_key" ]; then
       [yY][eE][sS] | [yY]) ;;
       *) echo "Left everything untouched."; exit 0 ;;
     esac
-    git -C "$repo" config core.sshCommand "ssh -i \"$configured_key\" -o IdentitiesOnly=yes"
+    git -C "$repo" config core.sshCommand "ssh -i $(printf '%q' "$configured_key") -o IdentitiesOnly=yes"
     git -C "$repo" config hooks.sshHostAlias "$alias_host"
     install_hooks
     ok=true
@@ -351,7 +351,7 @@ git -C "$repo" config user.name "$personal_git_name"
 git -C "$repo" config user.email "$personal_git_email"
 # Kept alongside the alias as a second layer: even if the remote is somehow
 # changed to plain github.com, the personal key is at least in the offered set.
-git -C "$repo" config core.sshCommand "ssh -i \"$selected_key\" -o IdentitiesOnly=yes"
+git -C "$repo" config core.sshCommand "ssh -i $(printf '%q' "$selected_key") -o IdentitiesOnly=yes"
 
 # Store the expected identity in the repo's git config for the guard hooks.
 git -C "$repo" config hooks.expectedName "$personal_git_name"

--- a/run_once_setup-ssh.sh
+++ b/run_once_setup-ssh.sh
@@ -63,7 +63,8 @@ ensure_alias_block() {
     # (when no block matches, ssh -G echoes the literal alias back as the hostname).
     # Don't append a duplicate — warn and leave it for manual reconciliation.
     echo "WARNING: 'Host $alias_host' already exists but resolves to HostName '$resolved_hostname', not github.com." >&2
-    echo "  Left untouched to avoid a duplicate block; reconcile it manually." >&2
+    echo "  Left untouched to avoid a duplicate block; edit your ssh config so that" >&2
+    echo "  'Host $alias_host' has 'HostName github.com', or remove the block and re-run." >&2
     return 0
   fi
 

--- a/run_once_setup-ssh.sh
+++ b/run_once_setup-ssh.sh
@@ -38,9 +38,11 @@ ssh_config="$ssh_dir/config"
 
 # Ensure ~/.ssh/config has a Host block for $alias_host pointing at the given key.
 # Existence is checked with `ssh -G` rather than grep so a block defined via an
-# Include also counts. If the alias exists but resolves to a different key, warn
-# and leave it alone — we never rewrite pre-existing ssh config; the pre-push
-# hook blocks pushes until it is reconciled.
+# Include also counts. If the alias exists but resolves to a different key or
+# hostname, warn and leave it alone — we never rewrite pre-existing ssh config.
+# Returns 0 when the alias resolves to github.com with the given key (or was just
+# added), 1 when an existing block was left in place that the pre-push hook will
+# block on until it is fixed by hand.
 ensure_alias_block() {
   local key="$1" resolved_hostname resolved_keys key_display
   resolved_hostname="$(ssh -G "$alias_host" 2>/dev/null | awk '/^hostname /{print $2}')"
@@ -56,6 +58,7 @@ ensure_alias_block() {
       echo "  (If a 'Host *' block in your ssh config also sets IdentityFile, that key shows" >&2
       echo "  up here too — remove it from 'Host *' so only this alias' key is offered.)" >&2
       echo "  Left untouched — align its IdentityFile manually; pushes are blocked until then." >&2
+      return 1
     fi
     return 0
   elif [ "$resolved_hostname" != "$alias_host" ]; then
@@ -65,7 +68,7 @@ ensure_alias_block() {
     echo "WARNING: 'Host $alias_host' already exists but resolves to HostName '$resolved_hostname', not github.com." >&2
     echo "  Left untouched to avoid a duplicate block; edit your ssh config so that" >&2
     echo "  'Host $alias_host' has 'HostName github.com', or remove the block and re-run." >&2
-    return 0
+    return 1
   fi
 
   mkdir -p "$ssh_dir"
@@ -238,12 +241,14 @@ if [ -n "$configured_key" ]; then
     git -C "$repo" config core.sshCommand "ssh -i \"$configured_key\" -o IdentitiesOnly=yes"
     git -C "$repo" config hooks.sshHostAlias "$alias_host"
     install_hooks
-    ensure_alias_block "$configured_key"
-    if ensure_remote; then
+    ok=true
+    ensure_alias_block "$configured_key" || ok=false
+    ensure_remote || ok=false
+    if $ok; then
       echo "Done — personal SSH set up for the dotfiles repo at $repo."
     else
-      echo "Personal SSH set up for the dotfiles repo at $repo — but origin still needs"
-      echo "to point at the '$alias_host' alias (see the note above) before you can push."
+      echo "Personal SSH set up for the dotfiles repo at $repo — but pushes stay blocked"
+      echo "until the warning(s) above are fixed."
     fi
     exit 0
   fi
@@ -337,11 +342,12 @@ git -C "$repo" config hooks.sshKey "$selected_key"
 git -C "$repo" config hooks.sshHostAlias "$alias_host"
 
 install_hooks
-ensure_alias_block "$selected_key"
-if ensure_remote; then
+ok=true
+ensure_alias_block "$selected_key" || ok=false
+ensure_remote || ok=false
+if $ok; then
   echo "Personal SSH identity configured for the dotfiles repo at $repo."
 else
-  echo "Personal SSH identity configured for the dotfiles repo at $repo — but origin"
-  echo "still needs to point at the '$alias_host' alias (see the note above) before you"
-  echo "can push."
+  echo "Personal SSH identity configured for the dotfiles repo at $repo — but pushes"
+  echo "stay blocked until the warning(s) above are fixed."
 fi

--- a/run_once_setup-ssh.sh
+++ b/run_once_setup-ssh.sh
@@ -40,9 +40,9 @@ ssh_config="$ssh_dir/config"
 # Existence is checked with `ssh -G` rather than grep so a block defined via an
 # Include also counts. If the alias exists but resolves to a different key or
 # hostname, warn and leave it alone — we never rewrite pre-existing ssh config.
-# Returns 0 when the alias resolves to github.com with the given key (or was just
-# added), 1 when an existing block was left in place that the pre-push hook will
-# block on until it is fixed by hand.
+# Returns 0 when the alias resolves to github.com with exactly the given key,
+# 1 when the ssh config still needs a fix by hand that the pre-push hook will
+# block on until it is done.
 ensure_alias_block() {
   local key="$1" resolved_hostname resolved_keys key_display
   resolved_hostname="$(ssh -G "$alias_host" 2>/dev/null | awk '/^hostname /{print $2}')"
@@ -88,6 +88,21 @@ ensure_alias_block() {
     echo "  IdentitiesOnly yes"
   } >>"$ssh_config"
   echo "Added 'Host $alias_host' to $ssh_config (IdentityFile $key_display)."
+
+  # Re-check now that the block is in place: IdentityFile accumulates across all
+  # matching blocks, so e.g. a 'Host *' that also sets one leaks an extra key —
+  # a state the pre-push hook blocks on, which the success message must not
+  # paper over.
+  resolved_keys="$(ssh -G "$alias_host" 2>/dev/null | sed -n 's/^identityfile //p' | sed "s|^~|$HOME|")"
+  if [ "$resolved_keys" != "$key" ]; then
+    echo "WARNING: another block in your ssh config (e.g. 'Host *') also sets IdentityFile," >&2
+    echo "  so 'Host $alias_host' resolves to:" >&2
+    printf '%s\n' "$resolved_keys" | sed 's/^/    /' >&2
+    echo "  instead of just the selected key: $key" >&2
+    echo "  Remove IdentityFile from that block so only this alias' key is offered;" >&2
+    echo "  pushes are blocked until then." >&2
+    return 1
+  fi
 }
 
 # Point origin at the alias so pushes can only ever offer the personal key.

--- a/run_once_setup-ssh.sh
+++ b/run_once_setup-ssh.sh
@@ -168,11 +168,14 @@ if [ "$actual_name" != "$expected_name" ] || [ "$actual_email" != "$expected_ema
   echo "BLOCKED: dotfiles repo push identity ($actual_name <$actual_email>) != expected ($expected_name <$expected_email>)" >&2
   exit 1
 fi
-remote="$(git config remote.origin.url)"
+# git hands pre-push the real destination ($1 = remote name or URL, $2 = URL),
+# which also covers pushurl and pushes to remotes other than origin —
+# remote.origin.url would miss both.
+remote="$2"
 # Enforce SSH so pushes use the key/identity above, not a cached HTTPS credential.
 case "$remote" in
   git@* | ssh://*) ;;
-  *) echo "BLOCKED: origin is not an SSH URL ($remote)" >&2; exit 1 ;;
+  *) echo "BLOCKED: push destination is not an SSH URL ($remote)" >&2; exit 1 ;;
 esac
 key="$(git config hooks.sshKey)"
 key="${key/#\~/$HOME}"
@@ -180,8 +183,8 @@ if [ -n "$key" ] && [ ! -f "$key" ]; then
   echo "BLOCKED: SSH key recorded for this repo not found: $key" >&2
   exit 1
 fi
-# When an alias is recorded: require origin to use it, require the alias to
-# resolve (a deleted ssh config block otherwise surfaces as a cryptic DNS
+# When an alias is recorded: require the push destination to use it, require the
+# alias to resolve (a deleted ssh config block otherwise surfaces as a cryptic DNS
 # error), and require it to resolve to exactly the recorded key — a second
 # candidate key would reintroduce the wrong-account ambiguity this setup
 # exists to prevent. `ssh -G` only parses local config; no network involved.
@@ -190,8 +193,8 @@ if [ -n "$alias_host" ]; then
   case "$remote" in
     git@"$alias_host":* | ssh://git@"$alias_host"/*) ;;
     *)
-      echo "BLOCKED: origin must use the '$alias_host' alias (got: $remote)" >&2
-      echo "Fix: git remote set-url origin git@$alias_host:<owner>/<repo>.git" >&2
+      echo "BLOCKED: pushes must use the '$alias_host' alias (got: $remote)" >&2
+      echo "Fix: git remote set-url $1 git@$alias_host:<owner>/<repo>.git" >&2
       exit 1
       ;;
   esac


### PR DESCRIPTION
## What

Configures a dedicated `github-personal` ssh alias for the dotfiles repo and makes re-runs safe.

- **Alias-per-identity:** routes the repo's origin through a `Host github-personal` block so only the personal key is ever offered to GitHub — even on machines whose `Host github.com` entry carries another identity (ssh matches on the name as typed, not the resolved HostName).
- **Guard hooks:** `pre-commit`/`pre-push` block commits/pushes made under the wrong identity, via a non-alias remote, or via an alias that no longer resolves to github.com with the recorded key.
- **Safe re-run path:** when the repo is already set up (`hooks.sshKey` set and the key exists), re-runs offer to set it up again rather than running full setup.

## Behavior on re-run

Nothing is modified without an interactive y/N:

- **No controlling terminal** (CI, piped, cron): prints what it found, modifies nothing, exits.
- **Interactive terminal:** shows what it found + a numbered list of what setting it up again does, then a single y/N gating *all* side effects (sshCommand, hooks, alias block, remote rewrite). Declining leaves everything untouched.

Not drift recovery: chezmoi only re-runs a `run_once_` script when its contents change, so deleting the alias block or `.git/hooks` won't trigger it — the `pre-push` hook blocks until you re-run the script.

## Validation

- `bash -n` OK
- `shellcheck` clean