### PR TITLE
fix(nvim): Restore eslint fix-on-save and TS "Move to file" action

### DIFF
--- a/dot_config/nvim/lua/plugins/lsp.lua
+++ b/dot_config/nvim/lua/plugins/lsp.lua
@@ -9,7 +9,7 @@ local function get_abs_deno_enable_paths()
   for _, unexpanded_path in ipairs(deno_enable_paths) do
     -- An item in `deno.enablePaths` can use wildcard(s) and hence reference multiple files
     ---@type string[]
-    expanded_paths = vim.fn.expand(unexpanded_path, nil, true)
+    local expanded_paths = vim.fn.expand(unexpanded_path, nil, true)
     for _, path in ipairs(expanded_paths) do
       unique_deno_enable_paths[vim.fn.fnamemodify(path, ":p")] = true
     end
@@ -22,9 +22,9 @@ end
 local function is_deno_enabled_file(filename)
   local file_path = vim.fn.fnamemodify(filename, ":p")
   for _, path in ipairs(get_abs_deno_enable_paths()) do
-    local match = string.find(file_path, path, 1, true)
-
-    if match then
+    -- Both paths are absolute, so anchor at the start rather than matching the
+    -- enable path anywhere in the filename.
+    if vim.startswith(file_path, path) then
       return true
     end
   end
@@ -37,71 +37,104 @@ return {
     "neovim/nvim-lspconfig",
     commit = "8055131", -- https://github.com/neovim/nvim-lspconfig/issues/4216
     opts = function(_, opts)
+      -- A server's `setup` handler is a single slot (LazyVim's lsp/init.lua does
+      -- `opts.setup[server] or opts.setup["*"]`), so overriding `setup.vtsls`
+      -- below would silently drop LazyVim's typescript-extra handler. Capture it
+      -- here so we can compose with it instead of clobbering it.
+      local lazyvim_vtsls_setup = opts.setup and opts.setup.vtsls
+
       return vim.tbl_deep_extend("force", opts, {
         inlay_hints = {
           enabled = false,
         },
+        servers = {
+          -- Declared on the server (not via `setup.eslint`) so it merges with
+          -- LazyVim's eslint extra instead of clobbering the extra's
+          -- `setup.eslint`, which registers eslint as a format-on-save source.
+          -- Very much based on https://github.com/neovim/nvim-lspconfig/blob/07f4e93de92e8d4ea7ab99602e3a8c9ac0fb778a/lsp/eslint.lua#L89
+          eslint = {
+            root_dir = function(bufnr, on_dir)
+              -- The project root is where the LSP can be started from
+              -- As stated in the documentation above, this LSP supports monorepos and simple projects.
+              -- We select then from the project root, which is identified by the presence of a package
+              -- manager lock file.
+              local root_markers = { "package-lock.json", "yarn.lock", "pnpm-lock.yaml", "bun.lockb", "bun.lock" }
+              -- Give the root markers equal priority by wrapping them in a table
+              root_markers = vim.fn.has("nvim-0.11.3") == 1 and { root_markers, { ".git" } }
+                or vim.list_extend(root_markers, { ".git" })
+
+              -- exclude deno
+              if is_deno_enabled_file(vim.api.nvim_buf_get_name(bufnr)) then
+                return
+              end
+
+              -- We fallback to the current working directory if no project root is found
+              local project_root = vim.fs.root(bufnr, root_markers) or vim.fn.getcwd()
+
+              on_dir(project_root)
+            end,
+          },
+        },
         setup = {
-          vtsls = function(_, opts)
-            if vim.lsp.config.denols and vim.lsp.config.vtsls then
-              ---@param server string
-              local resolve = function(server)
-                local markers, root_dir = vim.lsp.config[server].root_markers, vim.lsp.config[server].root_dir
-                vim.lsp.config(server, {
-                  root_dir = function(bufnr, on_dir)
-                    local is_deno = is_deno_enabled_file(vim.api.nvim_buf_get_name(bufnr))
+          vtsls = function(server, sopts)
+            if not (vim.lsp.config.denols and vim.lsp.config.vtsls) then
+              return
+            end
 
-                    if server == "denols" then
-                      if not is_deno then
-                        return nil
-                      end
-                      if root_dir then
-                        return root_dir(bufnr, on_dir)
-                      elseif type(markers) == "table" then
-                        local root = vim.fs.root(bufnr, markers)
-                        return root and on_dir(root)
-                      end
+            -- Capture the *stock* root resolution for both servers before the
+            -- extra wraps them, so our override delegates to the real defaults
+            -- rather than the extra's deno.json-marker wrapper.
+            local stock = {}
+            for _, name in ipairs({ "denols", "vtsls" }) do
+              stock[name] = {
+                markers = vim.lsp.config[name].root_markers,
+                root_dir = vim.lsp.config[name].root_dir,
+              }
+            end
+
+            -- Run the extra's setup for its side effects: the
+            -- `_typescript.moveToFileRefactoring` command handler ("Move to file"
+            -- code action) and the TypeScript -> JavaScript settings copy. It
+            -- also installs its own deno.json-marker root split, which we
+            -- overwrite below.
+            if lazyvim_vtsls_setup then
+              lazyvim_vtsls_setup(server, sopts)
+            end
+
+            -- Override root resolution with our neoconf `deno.enablePaths` aware
+            -- version (handles deno files inside an npm monorepo without their
+            -- own deno.json, and gates which server attaches).
+            ---@param name string
+            local resolve = function(name)
+              local markers, root_dir = stock[name].markers, stock[name].root_dir
+              vim.lsp.config(name, {
+                root_dir = function(bufnr, on_dir)
+                  local is_deno = is_deno_enabled_file(vim.api.nvim_buf_get_name(bufnr))
+
+                  if name == "denols" then
+                    if not is_deno then
+                      return nil
                     end
-
-                    if server == "vtsls" then
-                      if is_deno then
-                        return nil
-                      end
-                      local root = vim.fs.root(bufnr, { "package.json", "tsconfig.json", ".git" })
+                    if root_dir then
+                      return root_dir(bufnr, on_dir)
+                    elseif type(markers) == "table" then
+                      local root = vim.fs.root(bufnr, markers)
                       return root and on_dir(root)
                     end
-                  end,
-                })
-              end
-              resolve("denols")
-              resolve("vtsls")
+                  end
+
+                  if name == "vtsls" then
+                    if is_deno then
+                      return nil
+                    end
+                    local root = vim.fs.root(bufnr, { "package.json", "tsconfig.json", ".git" })
+                    return root and on_dir(root)
+                  end
+                end,
+              })
             end
-          end,
-          -- Very much based on https://github.com/neovim/nvim-lspconfig/blob/07f4e93de92e8d4ea7ab99602e3a8c9ac0fb778a/lsp/eslint.lua#L89
-          eslint = function(_, opts)
-            vim.lsp.config("eslint", {
-              root_dir = function(bufnr, on_dir)
-                -- The project root is where the LSP can be started from
-                -- As stated in the documentation above, this LSP supports monorepos and simple projects.
-                -- We select then from the project root, which is identified by the presence of a package
-                -- manager lock file.
-                local root_markers = { "package-lock.json", "yarn.lock", "pnpm-lock.yaml", "bun.lockb", "bun.lock" }
-                -- Give the root markers equal priority by wrapping them in a table
-                root_markers = vim.fn.has("nvim-0.11.3") == 1 and { root_markers, { ".git" } }
-                  or vim.list_extend(root_markers, { ".git" })
-
-                -- exclude deno
-                -- if vim.fs.root(bufnr, { "deno.json", "deno.jsonc", "deno.lock" }) then
-                if is_deno_enabled_file(vim.api.nvim_buf_get_name(bufnr)) then
-                  return
-                end
-
-                -- We fallback to the current working directory if no project root is found
-                local project_root = vim.fs.root(bufnr, root_markers) or vim.fn.getcwd()
-
-                on_dir(project_root)
-              end,
-            })
+            resolve("denols")
+            resolve("vtsls")
           end,
         },
       })


### PR DESCRIPTION
## What

Restores two LazyVim features that the custom deno/non-deno LSP routing was silently disabling:

- **eslint fix-on-save** — saving applies eslint autofixes again.
- **TypeScript "Move to file"** code action — the `vtsls` refactor now works.

## Why

The custom routing lived in `setup.eslint` and `setup.vtsls` handlers. Those are single-slot in LazyVim (`opts.setup[server] or opts.setup["*"]`), so they replaced the eslint/typescript extras' own handlers — dropping eslint's format-on-save registration and `vtsls`' `_typescript.moveToFileRefactoring` handler.

## How

- **eslint**: moved the neoconf-aware `root_dir` to declarative `servers.eslint.root_dir`, so it merges with the eslint extra instead of clobbering its `setup.eslint`.
- **vtsls**: capture the stock `denols`/`vtsls` root config, run the typescript extra's `setup.vtsls` for its side effects, then override `root_dir` with the neoconf `deno.enablePaths`-aware version.
- Also fixed a leaked global (`expanded_paths` -> `local`) and anchored the deno path match at the start (`vim.startswith` instead of `string.find`).

Behavior verified in an isolated `NVIM_APPNAME` sandbox: eslint attaches at the lockfile root and its formatter registers; the "Move to file" handler survives; and mixed deno/npm routing is correct per-file (including a deno file with no `deno.json` of its own).