### PR TITLE
chore(nvim): Disable `deno fmt`s max-linewidth on temp `.md` files

### DIFF
--- a/dot_config/nvim/lua/plugins/formatting.lua
+++ b/dot_config/nvim/lua/plugins/formatting.lua
@@ -1,3 +1,16 @@
+local deno_fmt_builtin = require("conform.formatters.deno_fmt")
+
+local function isTemporaryFile(filename)
+  if not filename or filename == "" then
+    return false
+  end
+  local tmp = vim.env.TMPDIR or "/tmp"
+  -- Resolve symlinks (e.g. macOS /var -> /private/var) so the prefix check matches
+  -- the realpath Neovim reports for the buffer, then ensure exactly one trailing slash
+  local tempDir = (vim.uv.fs_realpath(tmp) or tmp):gsub("/+$", "") .. "/"
+  return vim.startswith(filename, tempDir)
+end
+
 return {
   "stevearc/conform.nvim",
   optional = true,
@@ -24,6 +37,15 @@ return {
       ["erlang"] = { "erlfmt" },
     },
     formatters = {
+      deno_fmt = {
+        args = function(self, ctx)
+          local args = deno_fmt_builtin.args(self, ctx)
+          if vim.bo[ctx.buf].filetype:match("markdown") and isTemporaryFile(ctx.filename) then
+            table.insert(args, "--options-prose-wrap=preserve")
+          end
+          return args
+        end,
+      },
       erlfmt = {
         command = "rebar3",
         args = { "fmt", "$FILENAME" },


### PR DESCRIPTION
Mainly targeting when editing PR descriptions with the `gh` CLI (which will open up in Neovim).